### PR TITLE
style: change line-height to unitless value

### DIFF
--- a/btn.css
+++ b/btn.css
@@ -1,7 +1,7 @@
 /*! btn.css */
 .btn {
 font-size: 1em;
-line-height: 2em;
+line-height: 2;
 display: inline-block;
 padding: 0 1em;
 cursor: pointer;


### PR DESCRIPTION
Making a case to change `line-height` to a unitless value since it supports it, and unitless values are typically preferred.
- https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#Prefer_unitless_numbers_for_line-height_values
- http://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/